### PR TITLE
Add history & knowledge graph overview; update pricing; add chat server skeleton

### DIFF
--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -1,0 +1,15 @@
+### Architecture
+
+#### Triad of Trust
+- **Genomes**: Unique hyperdimensional vector storage objects built from 10 Helices and 10 Base Pairs each. Each Genome holds content or data and cryptographic proofs ensuring uniqueness and integrity【887808116772823†L21-L31】.
+- **Genes**: Special Genomes representing identity and access control. Genes implement capability-based security and are bound to biometrics or devices. They allow the owner to use, exclude, transfer or destroy Genomes【887808116772823†L21-L31】.
+- **Vaults**: Self-contained execution environments (trusted execution environments) that store Genomes (assets) and Genes (owner identities). Vaults run on devices or servers using hardware isolation technologies (Intel SGX, AMD SEV, ARM TrustZone) and ensure actual possession storage【887808116772823†L21-L31】.
+
+#### OnliOne components
+- **Onli (the asset)**: The unitary digital object – a Genome. It carries its own history and proves its integrity without referencing a global ledger【887808116772823†L21-L31】.
+- **Onli You**: The application (mobile or desktop) that hosts a Vault and allows owners to interact with their assets. It includes an authenticator for secure identity.
+- **Onli Cloud**: A functions-as-a-service (FaaS) environment that orchestrates issuance, transfers, AskToMove/Locker flows, Oracle registration and settlement. Onli Cloud never stores asset data; it logs receipts and ensures atomic transfers【887808116772823†L88-L100】.
+- **Appliances**: Client or server applications built by developers on top of Onli Cloud. Appliances provide user experiences and enforce business rules. They call Onli Cloud’s gRPC APIs to mint, move, or destroy Genomes【887808116772823†L88-L100】.
+- **Oracle**: The replicated validation oracle that records events (Issue, AskToMove, Locker, ChangeOwner) to provide verifiable receipts and anchor states off-chain.
+- **Locker**: A settlement vault used to hold Genomes under conditions (payment, compliance or time). Movement through the Locker ensures atomic settlement.
+- **Treasury & Mint**: Special vaults used by Issuers. Treasury holds unissued Genomes; Mint contains algorithms to create new Genomes.

--- a/docs/knowledge/definitions.md
+++ b/docs/knowledge/definitions.md
@@ -9,14 +9,12 @@ A technology that ensures the unique quantification of stored and transferred da
 A private computing network of hyper‑dimensional vector storage systems. It contains Vaults and Owners and enables uniqueness quantification across connected devices.
 
 ## Vaults
-Self‑contained execution environments that store Genomes (assets) and Genes (owner identities). Each Vault is under the direct control of its owner and acts as the secure storage for assets, ensuring actual possession【887808116772823†L21-L31】.
-
+Self‑contained execution environments functioning as OnliVaults – high‑security databases that store Onli (Genomes coupled with Genes). Each Vault enforces actual possession and is under the direct control of its owner. Vaults Vaults run in trusted execution environments (TEEs) and use hardware isolation to secure and execute computations on assets.
 ## Assets (Branded Genomes)
-Branded Genomes that live in Vaults. A generic asset is called an Onli.
+An Asset is a branded Onli: a non‑fungible (unique) document tightly coupled to an unforgeable credential (Gene) and a protocol. It can represent micro‑currencies or micro‑commodities. Assets encapsulate value via a hyperdimensional tensor data model and protocol rules for movement, enforced by Genes and the trusted execution environment.
 
 ## Genomes
-Hyperdimensional vector storage objects composed of 10 Helices. They serve as unique digital objects – “Genomes” evolve as they move from one owner to another【887808116772823†L21-L31】.
-
+Genomes are hyperdimensional vector storage containers arranged as multi‑dimensional tensors (e.g., three‑dimensional arrays). Coupled with a Gene, they form an OOnli. Instead of duplicating data, operations such as send or copy invoke the uniqueness quantification algorithm, which evolves the Genome's internal state. This ensures there is always one unique instance across all vaults.
 ## Helices
 Hyperdimensional vectors that make up a Genome. Each Genome contains 10 Helices.
 
@@ -24,6 +22,12 @@ Hyperdimensional vectors that make up a Genome. Each Genome contains 10 Helices.
 Fundamental data representations inside a Helix. Each Base Pair stores an attribute–value pair.
 
 ## Genes
+Genes are unforgeable credentials that represent an owner’s digital identity. They include agents for security, identity, authentication, and authorization, and they are tied to a Vault and its owner. Only the holder of the Gene can access or move the associated assets.
+
+
+## Uniqueness Quantification & Evolution
+Onli ensures uniqueness through a non‑deterministic algorithm that evolves a Genome whenever operations like send or copy occur. Instead of duplicating data, the container’s state is updated, preserving a single global version. These evolutionary transfer mechanisms make Onli resistant to cloning, spoofing, and hacking, while enabling assets to maintain a real‑time global state across connected devices.
+
 Special Genomes that represent an owner’s digital identity. They contain agents for security, identity, authentication and authorization and are tied to a Vault and Owner【887808116772823†L21-L31】.
 
 ## Agents

--- a/docs/knowledge/definitions.md
+++ b/docs/knowledge/definitions.md
@@ -1,0 +1,48 @@
+# Definitions
+
+This document defines the core entities in the Onli ecosystem.
+
+## ONLI™
+A technology that ensures the unique quantification of stored and transferred data.
+
+## OnliOne
+A private computing network of hyper‑dimensional vector storage systems. It contains Vaults and Owners and enables uniqueness quantification across connected devices.
+
+## Vaults
+Self‑contained execution environments that store Genomes (assets) and Genes (owner identities). Each Vault is under the direct control of its owner and acts as the secure storage for assets, ensuring actual possession【887808116772823†L21-L31】.
+
+## Assets (Branded Genomes)
+Branded Genomes that live in Vaults. A generic asset is called an Onli.
+
+## Genomes
+Hyperdimensional vector storage objects composed of 10 Helices. They serve as unique digital objects – “Genomes” evolve as they move from one owner to another【887808116772823†L21-L31】.
+
+## Helices
+Hyperdimensional vectors that make up a Genome. Each Genome contains 10 Helices.
+
+## Base Pairs
+Fundamental data representations inside a Helix. Each Base Pair stores an attribute–value pair.
+
+## Genes
+Special Genomes that represent an owner’s digital identity. They contain agents for security, identity, authentication and authorization and are tied to a Vault and Owner【887808116772823†L21-L31】.
+
+## Agents
+Autonomous programs that compute base pairs. Agents operate within Vaults and OnliOne to enforce policies and implement behaviours.
+
+## Owners
+Human users of OnliOne. Each owner possesses a Gene and can own assets (Genomes). Owners authenticate and authorize actions via their Gene.
+
+## Issuers
+Special users that mint and issue assets to owners. Issuers own Treasuries.
+
+## Treasuries
+Special vaults that store newly minted, unissued assets.
+
+## Mint
+A special vault containing the algorithms for generating unowned assets (Genomes).
+
+## Appliances
+Applications running on the Onli Cloud OS. Appliances interact with owners and implement business logic (e.g., marketplaces, digital wallets). Developers build Appliances to connect clients (Onli You) to the Onli Cloud.
+
+## ONLI Cloud
+A cloud operating system that manages the operation and execution of the OnliOne network. It provides functions‑as‑a‑service (FaaS) for issuance, transfers, settlement and Oracle registration but never stores the asset itself【887808116772823†L88-L100】.

--- a/docs/knowledge/implementation.md
+++ b/docs/knowledge/implementation.md
@@ -1,0 +1,39 @@
+# Implementation
+
+This document provides a step‑by‑step guide for deploying Onli in practice and integrating it into enterprise workflows.
+
+## Provision Vaults and Genes
+Every Onli deployment starts with secure storage: Vaults and Genes. Vaults are trusted execution environments that hold Genomes and Genes. Create a Vault for each owner or service account. During onboarding, each user or application receives a Gene (Onli ID) bound to their Vault’s hardware and biometric factors. Genes manage identity and enforce capability‑based security.
+
+## Define asset types and build configurations
+Identify the kinds of digital objects you plan to store (credentials, contracts, invoices, certificates, etc.). For each, choose a build configuration:
+- **Denomination** for microcurrencies or balances where totals are expressed via `amount`.
+- **Symmetric** for real‑world assets or receipts where every unit is a 1:1 asset.
+- **Series** for microcommodities with classes or tranches.
+Define asset metadata (class, face, series) and enforce business rules in your appliance.
+
+## Mint Genomes and ingest data
+Use the Vault SDK or Onli Cloud API to mint Genomes from your source data. Each minted Genome is uniquely identified and stored in your Vault. For AI and search use cases, embed a vector representation of the data and store it alongside the original content. You can define custom asset schemas and attach metadata that your appliance will use for indexing and retrieval.
+
+## Implement transfer flows
+Onli transfers are implemented with the `AskToMove → Locker → (Locker Condition) → ChangeOwner / ChangeOwners` flow.
+- **AskToMove:** the current owner authorizes the movement of an asset.
+- **Locker:** the asset moves into an escrow vault until conditions are met or, for simple owner‑to‑owner transfers, immediately releases.
+- **Condition:** apply a condition such as payment confirmation or regulator approval. For direct transfers or self‑vault moves, this is null.
+- **ChangeOwner(s):** finalize the transfer to the new owner(s).
+Your appliance should orchestrate these calls to the Onli Cloud API and enforce additional business logic (pricing, matching, KYC).
+
+## Register receipts and Oracle events
+Every transfer or mutation produces a receipt that can be pushed to Onli Cloud. Receipts contain minimal metadata and cryptographic hashes; they do not expose asset contents. Use the Oracle service to register external proofs such as payment confirmation, KYC outcomes, or other conditions required by your workflow. These records enable audits and regulatory compliance.
+
+## Integrate with existing systems
+Onli can coexist with traditional databases, data lakes and vector stores. Build connectors or middleware to:
+- Synchronize reference data and metadata between Onli and your other systems.
+- Use vector embeddings from Genomes in machine learning pipelines and semantic search.
+- Provide user interfaces (via Onli You or custom apps) that surface Genomes to end users while enforcing Onli’s access control.
+
+## Monitor, secure and scale
+Design policies for credential recovery, key rotation and dual custody for high‑value assets. Monitor Vault health and Vault transactions. As your deployment grows, scale horizontally by running multiple Vault instances and distributing workloads across Onli Cloud. Because Onli is private by default, ensure you have procedures for authorized inspections and disaster recovery.
+
+## Continuous improvement
+Update your appliances and asset definitions as business requirements evolve. Stay informed about new Onli features and build configurations. Periodically review your use cases to ensure Onli continues to provide value and meets regulatory and organizational needs.

--- a/docs/knowledge/implementation.md
+++ b/docs/knowledge/implementation.md
@@ -1,4 +1,4 @@
-# Implementation
+            # Implementation
 
 This document provides a step‑by‑step guide for deploying Onli in practice and integrating it into enterprise workflows.
 
@@ -21,7 +21,8 @@ Onli transfers are implemented with the `AskToMove → Locker → (Locker Condit
 - **Locker:** the asset moves into an escrow vault until conditions are met or, for simple owner‑to‑owner transfers, immediately releases.
 - **Condition:** apply a condition such as payment confirmation or regulator approval. For direct transfers or self‑vault moves, this is null.
 - **ChangeOwner(s):** finalize the transfer to the new owner(s).
-Your appliance should orchestrate these calls to the Onli Cloud API and enforce additional business logic (pricing, matching, KYC).
+Your appliance should orchestrate these calls to the Onli Cloud API and enforce additional business logic (
+pricing, matching, KYC).
 
 ## Register receipts and Oracle events
 Every transfer or mutation produces a receipt that can be pushed to Onli Cloud. Receipts contain minimal metadata and cryptographic hashes; they do not expose asset contents. Use the Oracle service to register external proofs such as payment confirmation, KYC outcomes, or other conditions required by your workflow. These records enable audits and regulatory compliance.
@@ -37,3 +38,15 @@ Design policies for credential recovery, key rotation and dual custody for high�
 
 ## Continuous improvement
 Update your appliances and asset definitions as business requirements evolve. Stay informed about new Onli features and build configurations. Periodically review your use cases to ensure Onli continues to provide value and meets regulatory and organizational needs.
+
+## Building an Onli Appliance
+
+An Onli Appliance is a client or server application that connects to OnliOne to create, store and transfer Assets on behalf of Owners. Appliances never store or process the contents of a Genome; instead, they manage references and metadata, call Onli Cloud APIs to perform secure transfers, and enforce business rules. To build an Appliance:
+
+1. **Define your Asset class and configuration.** Decide whether your Asset is a micro‑currency (`Denomination`), a 1:1 receipt or record (`Symmetric`), or a series‑based micro‑commodity (`Series`). Use this to inform your application logic and data model.
+2. **Provision Vaults and Genes.** Ensure each participant has a Vault (via OnliYou or the Vault SDK) and associated Gene credentials. Appliances should never handle Gene material; they only direct owners to authorize operations.
+3. **Mint Assets via Onli Cloud.** Use the Onli Cloud API (`POST /issue`) or the Vault SDK to create new Genomes in the issuer’s Treasury. Attach any required metadata and embedding vectors for AI or search use cases. Only the issuer can mint new Assets.
+4. **Implement AskToMove and transfer flows.** For every move, call `POST /askToMove` to request owner authorization, wait for the Locker condition to be satisfied (null for direct transfers), then call `POST /changeOwner` or `POST /changeOwners` to complete the transfer. Appliances handle settlement logic (e.g. verifying payment, KYC, or time locks) and define Locker conditions.
+5. **Interact with owners through the OnliYou app or your own UI.** Present owners with clear prompts to authorize transfers via AskToMove and monitor the status of their Vaults. Use Onli Cloud webhooks or polling to update your UI when transfers complete.
+6. **Record receipts and audit events.** After each transfer, Onli Cloud emits a receipt and Oracle entry. Store these in your application database for provenance and reconciliation; never expose the underlying Genome content.
+7. **Follow security best practices.** Do not store, copy, or transmit Genome contents. Use Genes to authenticate owners and enforce permissions. Ensure your application backend runs in secure environments and that only authorized services can call Onli Cloud.

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -1,0 +1,9 @@
+# Onli Knowledge Index
+
+This folder contains the structured knowledge base for Onli. Each file covers a major aspect of the platform:
+
+- **definitions.md** – Glossary of core terms (OnliOne, Vaults, Genomes, Genes, Helices, Base Pairs, Agents, Owners, Issuers, Treasury, Mint, Appliances, ONLI Cloud).
+- **architecture.md** – Overview of the Triad of Trust (Genomes, Genes, Vaults) and the components of OnliOne (Onli, Onli You, Onli Cloud, Appliances).
+- **use_cases.md** – Examples of how Onli can be applied across eight domains: credentials & verification, contracts & legal instruments, finance & commerce, luxury & art, healthcare & personal records, government & public services, enterprise workflows, and consumer use.
+- **implementation.md** – Guidance on deploying Onli: setting up Vaults and Genes, minting Genomes, using AskToMove → Locker → Condition → ChangeOwner flows, and integrating with existing systems.
+- **pricing_and_history.md** – Details on Onli’s history (founded in 2010 by Dhryl Anton, Michael McFall, Peter Jenson Haxel, and Michaela Katherine Anton) and current pricing (developer subscriptions and treasury issuance costs).

--- a/docs/knowledge/pricing_and_history.md
+++ b/docs/knowledge/pricing_and_history.md
@@ -1,0 +1,16 @@
+# Pricing and History
+
+## History & Founders
+Onli was founded in 2010 by Dhryl Anton, Michael McFall, Peter Jenson Haxel, and Michaela Katherine Anton. These founders created Onli to solve the problem of uniqueness and ownership of digital objects. The company has since developed Onli One, Onli Cloud, and a suite of developer tools for issuing and managing digital assets with cryptographic security and actual possession.
+
+## Pricing and Costs
+Onli’s pricing model is straightforward. For developers building Appliances:
+
+- **Developer subscription**: $500 per month, or $6,000 per year for a team of three. This subscription grants access to Onli Cloud APIs, Vault infrastructure, and developer support.
+
+- **Treasury issuance fee**: $50,000 per billion units (sold only in billion-unit increments), plus $0.05 per asset issued. This fee covers the cost of minting a batch of unissued Genomes in a Treasury vault. There are no ongoing transaction, gas or mining fees beyond the initial issuance.
+
+- **No hidden fees**: Onli Cloud does not charge percentages of asset value or transaction fees. Costs are based on infrastructure and issuance only.
+
+## Deployment Considerations
+For a typical enterprise deployment, plan for the developer subscription and treasury issuance costs. Additional expenses may include infrastructure for Vaults (e.g. secure enclaves) and professional services for integrating Onli with your existing systems. Onli provides consultation and support packages to assist with architecture, compliance and custom Appliance development.

--- a/docs/knowledge/use_cases.md
+++ b/docs/knowledge/use_cases.md
@@ -1,0 +1,41 @@
+### Use Cases
+
+#### Credentials & Verification
+- **Academic credentials**: universities issue diplomas and transcripts as Genomes stored in the student's Vault; employers verify authenticity instantly.
+- **Professional licenses & certifications**: doctors, pilots and lawyers carry their licenses as Genomes, reducing fraud and counterfeit risk.
+- **KYC/AML verification**: banks issue a verified identity Genome; customers present their Genome instead of repeated KYC checks.
+
+#### Contracts & Legal Instruments
+- **Private contracts** (NDAs, employment agreements, partnership agreements) become unique Genomes held by each party.
+- **Title deeds & property transfers**: property rights are preserved via “possession = ownership,” enabling direct transfers without registries.
+- **Corporate resolutions or board minutes**: recorded as Genomes in Vaults to prevent tampering.
+
+#### Finance & Commerce
+- **Financial instruments**: bonds, invoices and credit notes are issued as Genomes that cannot be duplicated.
+- **Proof of payment & receipts**: merchants issue receipts as Genomes, which customers store in their Vaults.
+- **Supply chain provenance**: each shipment or component gets a Genome at each stage, ensuring authenticity without public ledgers.
+
+#### Luxury, Art & Collectibles
+- **Certificates of authenticity**: artworks, watches or wine include a Genome that travels with the item.
+- **One-of-one digital works**: artists mint unique files as Genomes (not NFTs), ensuring singularity.
+- **Hospitality experiences**: guests receive “experience Genomes” tied to their stay for proof-of-visit.
+
+#### Healthcare & Personal Records
+- **Medical records**: each test result or record is issued as a Genome bound to the patient’s Vault; selectively shareable with doctors.
+- **Vaccination proof**: tamper-proof Genomes replace QR codes.
+- **Clinical trial data**: trial datasets are issued as Genomes, ensuring provenance and regulatory compliance.
+
+#### Government & Public Services
+- **Digital IDs & passports**: issued as Genomes; citizens hold them without government-maintained blockchains.
+- **Voting tokens**: unique Genomes for each ballot ensure one-person-one-vote without public ledgers.
+- **Permits & licenses**: fishing permits, construction approvals, etc., issued as verifiable Genomes.
+
+#### Enterprise & Workflows
+- **Internal document control**: sensitive files (design docs, roadmaps, research papers) become Genomes, ensuring no duplicates.
+- **Employee credentials**: HR issues employment verification Genomes for instantaneous background checks.
+- **Confidential communications**: messages or presentations become Genomes, providing authenticity and integrity.
+
+#### Consumer & Everyday Use
+- **Personal archives**: individuals store receipts, contracts and guarantees as Genomes in their Vault.
+- **Digital creations**: musicians, writers and designers wrap their work as a Genome to establish proof-of-origin.
+- **Membership passes**: gyms, clubs or events issue unique Genomes instead of QR or barcode passes.

--- a/docs/onli_knowledge_base.md
+++ b/docs/onli_knowledge_base.md
@@ -103,3 +103,33 @@ The **Brands** slide deck explained Onli’s fundamental differentiator: it solv
 Onli provides a groundbreaking approach to digital asset management. By combining cryptographic uniqueness with secure identity and actual possession, Onli enables a vast array of applications that benefit from authenticity, provenance and owner control. The use cases outlined here demonstrate how Genomes, Genes, Vaults and Appliances can reshape industries ranging from education and healthcare to finance and government. Unlike blockchains, Onli has no global ledger, no mining and no tokens. Instead, it offers a **private-by-default** network where assets move directly between owners and the proof of transfer is recorded in an **Oracle** only as needed for verification.
 
 Organizations adopting Onli can start with small pilots — perhaps issuing credentials or managing sensitive documents — and expand to more complex scenarios like microcurrency and micro-commodity exchanges. For consumers, Onli means personal data can be truly yours, stored in your Vault and shared only when you decide. For enterprises, Onli offers a way to manage digital assets that is secure, compliant and aligned with real-world ownership. As digital transformation accelerates and the value of data grows, Onli’s model of unique, self-contained digital objects may become a foundation for the next generation of data storage and control.
+
+### History & Founders
+
+Onli was founded in 2010 by Dhryl Anton, Michael Mcfall, Peter Jenson Haxel, and Michaela Katherine Anton. These founders envisioned a new paradigm for digital ownership and data storage, leading to the development of Onli’s Genomes, Genes and Vaults architecture.
+
+### Knowledge Graph Overview
+
+The core entities in the Onli ecosystem are:
+
+- **OnliOne** – A private computing network of hyper-dimensional vector storage systems. It contains Vaults and Owners and provides uniqueness quantification across a network of connected devices.
+- **Vaults** – Self-contained execution environments within OnliOne. Vaults store Genomes (Assets) and Genes (Owner identities) and provide actual possession storage of Assets.
+- **Asset** – A branded Genome within OnliOne. The generic term for an Onli Asset is an “Onli.”
+- **Genome** – A hyperdimensional vector storage object within a Vault. Each Genome contains 10 Helices and represents a unique object.
+- **Helix** – A hyperdimensional vector that is part of a Genome. Each Helix contains 10 Base Pairs and stores data segments related to different facets of the object’s dimensions.
+- **Base Pair** – The fundamental data representation within a Helix. Each Base Pair stores an attribute–value pair.
+- **Gene** – A special Genome representing an owner’s digital identity. Genes contain agents for security, identity, authentication and authorization and reside within Vaults and Owners.
+- **Agents** – Autonomous programs that compute Base Pairs and enforce logic. Agents are part of OnliOne and live inside Vaults.
+- **Owners** – Human users of OnliOne who possess Genes, own Assets (Genomes) and use Vaults to store their balances of Assets and capabilities.
+- **Issuers** – Special users of OnliOne who mint Assets. Issuers own Treasuries and issue Assets to Owners.
+- **Treasury** – A special Vault used to store newly minted, unissued Assets.
+- **Mint** – A special Vault containing algorithms for generating unowned Genomes.
+- **Appliances** – Applications running on the ONLI Cloud OS. Appliances interact with Owners and implement business logic using Onli’s Genomes and Genes.
+- **ONLI Cloud** – A cloud operating system that manages computing infrastructure for OnliOne. It interacts with developers via a gRPC API and hosts services such as the Replicated Validation Oracle, Transfer Agent and others.
+
+### Deployment & Pricing
+
+Onli is offered as enterprise software rather than a public blockchain network. Pricing reflects actual possession rather than network fees:
+
+- **Developer subscription** – The base developer plan costs $500 per month (or $6,000 per year) for a team of three developers.
+- **Treasury issuance** – Issuers pay $50,000 per billion units issued (sold only in one-billion-unit increments) plus a one‑time $0.05 fee per issuance. There are no other recurring fees.

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,11 @@ const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch
 
 // Hardcoded rule responses
 const RULES = [
+    {
+    match: q => /(what.*onli.*do|how.*use.*onli|onli.*capabilities)/i.test(q),
+    answer: "Onli is a kind of intelligible data that is stored in an OnliVault, a high-security database. To use an Onli you need to build an appliance that connects to the Onli Cloud."
+  },
+
   {
     match: q => /(price|pricing|cost).*developer/i.test(q),
     answer: "Developers: $500/month or $6,000/year for a team of 3. Treasury: $50,000 per billion units (sold in billion-unit increments) + $0.05 per issue. No other fees."

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,78 @@
+const express = require('express');
+
+// If using Node 18 or above, fetch is globally available. Otherwise require node-fetch.
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+
+// Hardcoded rule responses
+const RULES = [
+  {
+    match: q => /(price|pricing|cost).*developer/i.test(q),
+    answer: "Developers: $500/month or $6,000/year for a team of 3. Treasury: $50,000 per billion units (sold in billion-unit increments) + $0.05 per issue. No other fees."
+  },
+  {
+    match: q => /treasury.*(fee|price|cost)/i.test(q),
+    answer: "Treasury: $50,000 per billion units (sold in billion-unit increments) + $0.05 per issue. No other fees."
+  },
+  {
+    match: q => /(founders?|founded|founding)/i.test(q),
+    answer: "Onli was founded in 2010 by Dhryl Anton, Michael Mcfall, Peter Jenson Haxel, and Michaela Katherine Anton."
+  },
+  {
+    match: q => /^what\s+is\s+onli\??$/i.test(q),
+    answer: "ONLI transfers possession of unique digital objects (Genomes) using Genes (identity) in Vaults (self-contained execution). It is not a blockchain or cryptocurrency."
+  },
+];
+
+// Load knowledge base from GitHub raw file
+async function loadKB() {
+  try {
+    const res = await fetch('https://raw.githubusercontent.com/OnliSyn/onli-mcp-service/main/docs/onli_knowledge_base.md');
+    return await res.text();
+  } catch (err) {
+    return '';
+  }
+}
+
+async function loadKB2() {
+  try {
+    const res = await fetch('https://raw.githubusercontent.com/OnliSyn/onli-mcp-service/main/docs/onli_comprehensive_knowledge_base.md');
+    return await res.text();
+  } catch (err) {
+    return '';
+  }
+}
+
+// Placeholder for LLM call; implement with your provider
+async function callLLM(messages) {
+  // Example: return { content: "LLM answer placeholder" };
+  return { content: "This is a placeholder response. Please integrate with your LLM provider." };
+}
+
+// Express server
+const app = express();
+app.use(express.json());
+
+app.post('/chat', async (req, res) => {
+  const query = String(req.body?.query || '').trim();
+  // Check rules
+  for (const rule of RULES) {
+    if (rule.match(query)) {
+      return res.json({ source: 'rule', answer: rule.answer });
+    }
+  }
+
+  // Default: call LLM with knowledge base context
+  const kb = await loadKB();
+  const kb2 = await loadKB2();
+  const messages = [
+    { role: 'system', content: 'You are an ONLI assistant. Use the provided context to answer.' },
+    { role: 'user', content: `Question: ${query}\n\nContext:\n${kb}\n\n${kb2}` },
+  ];
+  const result = await callLLM(messages);
+  res.json({ source: 'llm', answer: result.content });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Chat server listening on port ${PORT}`);
+});


### PR DESCRIPTION
This pull request adds several enhancements to the repository:

- Extends the knowledge base with a History & Founders section and a Knowledge Graph Overview summarizing OnliOne, Vaults, Assets, Genomes, Helices, Base Pairs, Genes, Agents, Owners, Issuers, Treasury, Mint, Appliances, and ONLI Cloud.
- Updates deployment & pricing details: developers cost $500/month or $6,000/year for a team of three; treasury issuance costs $50,000 per billion units plus $0.05 per issue.
- Adds a `server/index.js` file implementing a Node/Express chat server skeleton with rule-based responses for fixed FAQs (pricing, founders), knowledge base retrieval from GitHub, and a placeholder for LLM integration.

This prepares the repository for integration with a chat application and provides a complete knowledge base for ONLI.